### PR TITLE
Fix Pillow installation error during deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ sqlparse==0.5.3
 gunicorn==22.0.0
 pandas==2.3.0
 whitenoise==6.6.0
-Pillow==10.1.0
+Pillow==9.5.0
 python-dotenv==1.0.1
 django-crispy-forms==2.1
 crispy-bootstrap5==2024.2


### PR DESCRIPTION
Updated Pillow to version 9.5.0 in requirements.txt. This version, in conjunction with necessary system dependencies (like python3-dev, build-essential, libjpeg-dev, zlib1g-dev), resolves the 'KeyError: __version__' encountered during the build process on Render with Python 3.13.